### PR TITLE
add node manipulation helpers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+on: [push, pull_request]
+jobs:
+    build:
+        name: Test
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                go: [ '1.16', '1.17', '1.18' ]
+                os: [ 'ubuntu-latest' ]
+        steps:
+            - uses: actions/checkout@v2
+            - name: Setup go
+              uses: actions/setup-go@v2
+              with:
+                go-version: ${{ matrix.go }}
+            - uses: actions/cache@v2
+              with:
+                path: ~/go/pkg/mod
+                key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+                restore-keys: |
+                    ${{ runner.os }}-go-
+            - name: Go Test
+              run: go test -v ./...
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+            - name: Setup go
+              uses: actions/setup-go@v2
+              with:
+                go-version: 1.17
+            - uses: actions/checkout@v3
+            - name: golangci-lint
+              uses: golangci/golangci-lint-action@v3
+              with:
+                version: v1.44

--- a/walk.go
+++ b/walk.go
@@ -87,7 +87,7 @@ func Walk(node *yaml.Node, f WalkFunc, walkOpts ...WalkOpt) error {
 	for _, o := range walkOpts {
 		o(opts)
 	}
-	node = unwrapDocument(node)
+	node = UnwrapDocument(node)
 	ws, err := f(node, nil, -1, opts)
 	if opts.trace != nil {
 		opts.trace(node, nil, -1, 0, ws, err)
@@ -306,7 +306,7 @@ func WalkPathMatchers(root *yaml.Node, fn NodeFunc, matchers ...PathMatcher) err
 			return matchers[i].Match(node, prevFn)
 		}
 	}
-	return matchFn(unwrapDocument(root))
+	return matchFn(UnwrapDocument(root))
 }
 
 func WalkPath(root *yaml.Node, fn NodeFunc, path ...interface{}) error {


### PR DESCRIPTION
Expose UnwrapDocuments (previouly private)
Add Indirect to automatically unalias if necessary
Add ReadFile to simplify reading a file to a yaml.Node
Add CopyNode and ShallowCopyNode to facilitate copying nodes.